### PR TITLE
Baro fix

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -43,6 +43,10 @@ using namespace simulator;
 #define UDP_PORT 	14550
 #define PIXHAWK_DEVICE "/dev/ttyACM0"
 
+#define PRESS_GROUND 101325.0f
+#define DENSITY 1.2041f
+#define GRAVITY 9.81f
+
 static const uint8_t mavlink_message_lengths[256] = MAVLINK_MESSAGE_LENGTHS;
 static const uint8_t mavlink_message_crcs[256] = MAVLINK_MESSAGE_CRCS;
 
@@ -183,7 +187,8 @@ void Simulator::update_sensors(struct sensor_combined_s *sensor, mavlink_hil_sen
 	write_mag_data((void *)&mag);
 
 	RawBaroData baro;
-	baro.pressure = imu->abs_pressure;
+	// calculate air pressure from altitude (valid for low altitude)
+	baro.pressure = PRESS_GROUND - GRAVITY * DENSITY * imu->pressure_alt;
 	baro.altitude = imu->pressure_alt;
 	baro.temperature = imu->temperature;
 

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -640,7 +640,7 @@ BAROSIM::collect()
         report.error_count = perf_event_count(_comms_errors);
 
 	/* read the most recent measurement - read offset/size are hardcoded in the interface */
-	ret = _interface->dev_read(0, (void *)&baro_report, 0);
+	ret = _interface->dev_read(0, (void *)&baro_report, sizeof(baro_report));
 	if (ret < 0) {
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);

--- a/src/platforms/posix/drivers/barosim/baro_sim.cpp
+++ b/src/platforms/posix/drivers/barosim/baro_sim.cpp
@@ -127,7 +127,7 @@ BARO_SIM::dev_read(unsigned offset, void *data, unsigned count)
 
 	/* read the most recent measurement */
 	uint8_t cmd = 0;
-	int ret = transfer(&cmd, 1, static_cast<uint8_t *>(data), 3);
+	int ret = transfer(&cmd, 1, static_cast<uint8_t *>(data), count);
 
 	/*
 	if (ret == PX4_OK) {
@@ -208,7 +208,7 @@ BARO_SIM::transfer(const uint8_t *send, unsigned send_len,
 	if (recv_len == 0) {
 		PX4_DEBUG("BARO_SIM measurement requested");
 	}
-	else if (send_len != 1 || send[0] != 0 || recv_len != 3) {
+	else if (send_len != 1 || send[0] != 0 ) {
 		PX4_WARN("BARO_SIM::transfer invalid param %u %u %u", send_len, send[0], recv_len);
 		return 1;
 	}


### PR DESCRIPTION
- compute atmospheric pressure from altitude
- use correct report length to read baro data from simulator